### PR TITLE
Issue 42

### DIFF
--- a/alpheios_nemo_ui/__init__.py
+++ b/alpheios_nemo_ui/__init__.py
@@ -64,7 +64,9 @@ class AlpheiosNemoUI(PluginPrototype):
     ]
 
     FILTERS = [
-        "f_hierarchical_passages_full"
+        "f_hierarchical_passages_full",
+        "f_i18n_citation_label",
+        "f_i18n_citation_item"
     ]
 
     CACHED = ["r_typeahead_json"]
@@ -77,6 +79,8 @@ class AlpheiosNemoUI(PluginPrototype):
         self.external_url_base = external_url_base
         self.clear_routes = True
         self.f_hierarchical_passages_full = filters.f_hierarchical_passages_full
+        self.f_i18n_citation_label = filters.f_i18n_citation_label
+        self.f_i18n_citation_item = filters.f_i18n_citation_item
         self._get_lang = _get_lang
 
     def r_index(self):

--- a/alpheios_nemo_ui/data/templates/alpheios/macros.html
+++ b/alpheios_nemo_ui/data/templates/alpheios/macros.html
@@ -1,19 +1,25 @@
 {% macro single_ref(objectId, subreference, human_reff) -%}
     <div class="card-text reff">
-        <a href="{{url_for('.r_passage', objectId=objectId, subreference=subreference)}}">{{ human_reff|i18n_citation_type }}</a>
+        <a href="{{url_for('.r_passage', objectId=objectId, subreference=subreference)}}">{{ human_reff|i18n_citation_item }}</a>
     </div>
 {%- endmacro %}
 
 {% macro reff_dict(objectId, reffs) -%}
-    {% for human_reff, dict_or_reff in reffs.items() %}
-        {% if dict_or_reff|is_str %}
-            {{ single_ref(objectId, dict_or_reff, human_reff) }}
-        {% else %}
-          <div class="card p-2 m-2">
-              <div class="card-header">{{human_reff|i18n_citation_type}}</div>
-                 {{ reff_dict(objectId, dict_or_reff) }}
-            </div>
+    {% set reffs = reffs.items() %}
+    {% for human_reff, dict_or_reff in reffs %}
+      {% if dict_or_reff|is_str %}
+        {% if loop.index == 1 %}
+          <div class="passages" data-type="{{human_reff|i18n_citation_label}}">
+        {% endif%}
+        {{ single_ref(objectId, dict_or_reff, human_reff) }}
+        {% if loop.index == reffs|length %}
+          </div>
         {% endif %}
+      {% else %}
+        <div class="card p-2 m-2" data-type="{{human_reff|i18n_citation_label}}" data-value="{{human_reff|i18n_citation_item}}">
+          {{ reff_dict(objectId, dict_or_reff) }}
+        </div>
+      {% endif %}
     {% endfor %}
 {%- endmacro %}
 

--- a/alpheios_nemo_ui/data/templates/alpheios/macros.html
+++ b/alpheios_nemo_ui/data/templates/alpheios/macros.html
@@ -1,6 +1,6 @@
 {% macro single_ref(objectId, subreference, human_reff) -%}
     <div class="card-text reff">
-        <a href="{{url_for('.r_passage', objectId=objectId, subreference=subreference)}}">{{ human_reff }}</a>
+        <a href="{{url_for('.r_passage', objectId=objectId, subreference=subreference)}}">{{ human_reff|i18n_citation_type }}</a>
     </div>
 {%- endmacro %}
 

--- a/alpheios_nemo_ui/filters.py
+++ b/alpheios_nemo_ui/filters.py
@@ -21,10 +21,38 @@ def f_hierarchical_passages_full(reffs, citation):
     for cit, name in reffs:
         ref = cit.split('-')[0]
         name = "%{}|{}%".format(levels[-1].name,name)
-        if (len(levels) > 1):
-            levs = ['%{}|{}%'.format(levels[i].name, v) for i, v in enumerate(ref.split('.'))]
-        else:
-            # make sure we have a lowest-level key
-            levs = ['%{}|%'.format(levels[0].name),None]
+        levs = ['%{}|{}%'.format(levels[i].name, v) for i, v in enumerate(ref.split('.'))]
         getFromDict(d, levs[:-1])[name] = cit
     return d
+
+def f_i18n_citation_label(string, lang="eng"):
+    """ Take a string of form %citation_type|passage% and format it as label
+
+    :param string: String of formation %citation_type|passage%
+    :param lang: Language to translate to
+    :return: Human Readable string
+
+    .. note :: To Do : Use i18n tools and provide real i18n
+    """
+    s = string.strip("%").split("|")
+    if len(s) > 1:
+        return s[0].capitalize()
+    else:
+        return string
+
+
+def f_i18n_citation_item(string, lang="eng"):
+    """ Take a string of form %citation_type|passage% and format it as item only
+
+    :param string: String of formation %citation_type|passage%
+    :param lang: Language to translate to
+    :return: Human Readable string
+
+    .. note :: To Do : Use i18n tools and provide real i18n
+    """
+    s = string.strip("%").split("|")
+    if len(s) > 1:
+        return s[1].capitalize()
+    else:
+        return string
+

--- a/alpheios_nemo_ui/filters.py
+++ b/alpheios_nemo_ui/filters.py
@@ -20,6 +20,7 @@ def f_hierarchical_passages_full(reffs, citation):
     levels = [x for x in citation]
     for cit, name in reffs:
         ref = cit.split('-')[0]
+        name = "%{}|{}%".format(levels[-1].name,name)
         if (len(levels) > 1):
             levs = ['%{}|{}%'.format(levels[i].name, v) for i, v in enumerate(ref.split('.'))]
         else:


### PR DESCRIPTION
@irina060981 this is an attempt at the flask side of changes for #42 

It's a bit hacky but the python code to pull the browse data structures together is convoluted and I'm trying to work with it without getting too far into rewriting it.

The references template calls the `hierarchical_dispatcher macro` with the reffs in the following possible structures

For a text which only has a single hierarchical level (such as Horace Ars Poetica which is by line only) it will contain just a list of tuples in the form `[ ("%<type>|<range>%","<range>"),..]` i.e. `[("%line|1-30%","1-30"),("%line|31-60","31-60")...]`

But for a text which has multiple hierarchical levels (which is most of them although the levels differ), it will contain a list of tuples in the form `[ (%<type>|<number>%",<ordereddict>), ..]` i.e. for Homer you have ` `[("%book|1%",[("%line|1-30%","1-30"),("%line|31-60","31-60")...),("%book|2%",[("%line|1-30%","1-30"),("%line|31-60","31-60")...),]`

To try to put thin in the terms of the suggested design, when we are down to a list of just string references and not a nested dictionary, we are at the "passages" level and want to show the cards as in https://github.com/alpheios-project/design-guidelines/blob/master/v3/AlpheiosReader-Mobile/Browse/Passage.png 

Otherwise, if we have a dict, then we have a parent level that needs to be shown as an expandable item as in https://github.com/alpheios-project/design-guidelines/blob/master/v3/AlpheiosReader-Mobile/Browse/Chapter.png

I felt it was better to leave it to you to do the css/html for the design, so I just put in a very basic structure there, which wraps the lowest level list in a `<div class="passages"></div>` . The higher level parents are in parent `<div>`s that currently use the `data-type` and `data-value` attributes to hold the level name and value.  E.g. so for Horace we just have 

```
<div class="passages">
     <div class="card-text reff">
        <a href="{{url_for('.r_passage', objectId=objectId, subreference=subreference)}}">{{ human_reff|i18n_citation_item }}</a>
    </div>
    <div class="card-text reff">
        <a href="{{url_for('.r_passage', objectId=objectId, subreference=subreference)}}">{{ human_reff|i18n_citation_item }}</a>
    </div>
   ...
</div>
```
whereas for Homer we have 

```
<div data-type="book", data-value="1">
  <div class="passages">
     <div class="card-text reff">
        <a href="{{url_for('.r_passage', objectId=objectId, subreference=subreference)}}">{{ human_reff|i18n_citation_item }}</a>
    </div>
    ...
  </div>
</div>
<div data-type="book", data-value="2">
  <div class="passages">
     <div class="card-text reff">
        <a href="{{url_for('.r_passage', objectId=objectId, subreference=subreference)}}">{{ human_reff|i18n_citation_item }}</a>
    </div>
    ...
  </div>
</div>
...

```

I'm hoping you can do some magic to turn this into a nice display that is at least close to what the design suggests. We may have to make some compromises.

