### PR TITLE
fix repo for latin canonical texts

### DIFF
--- a/get_texts.sh
+++ b/get_texts.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 mkdir texts
-curl -L https://github.com/PerseusDL/canonical-latinLit/archive/master.zip > ./texts/canonical-latinLit.zip
+curl -L https://github.com/alpheios-project/canonical-latinLit/archive/master.zip > ./texts/canonical-latinLit.zip
 curl -L https://github.com/PerseusDL/canonical-greekLit/archive/master.zip > ./texts/canonical-greekLit.zip
 curl -L https://github.com/alpheios-project/cts-texts-latinLit/archive/master.zip > ./texts/alpheios-latinLit.zip
 curl -L https://github.com/alpheios-project/cts-texts-greekLit/archive/master.zip > ./texts/alpheios-greekLit.zip


### PR DESCRIPTION
@kirlat and @irina060981 fyi, sorry this was a difference between the production and development environments --- we are currently using our fork of the original repo for these texts because I have changes to the metadata that I haven't submitted to the source repo yet (and which might not be accepted there anyway)