### PR TITLE
Add an error activation handler and browser detect in it

### DIFF
--- a/alpheios_nemo_ui/data/templates/main/container.html
+++ b/alpheios_nemo_ui/data/templates/main/container.html
@@ -117,7 +117,7 @@
           })
 
         }).catch(e => {
-          console.error(`Import of an embedded library failed: ${e}`)
+          console.error(`Import of an embedded library dependencies failed: ${e}`)
         })
       });
 

--- a/alpheios_nemo_ui/data/templates/main/container.html
+++ b/alpheios_nemo_ui/data/templates/main/container.html
@@ -64,6 +64,7 @@
 
       if (allowedBrowsers.indexOf(browserData.name) === -1) {
         console.error('Your browser is not supported by Alpheios Extension. Please use Chrome, Firefox or Safari.')
+        window.alert('Your browser is not supported by Alpheios Extension. Please use Chrome, Firefox or Safari.')
       } else {
         console.error(message)
       }

--- a/alpheios_nemo_ui/data/templates/main/container.html
+++ b/alpheios_nemo_ui/data/templates/main/container.html
@@ -117,7 +117,7 @@
           })
 
         }).catch(e => {
-          console.error(`Import of an embedded library dependencies failed: ${e}`)
+          console.error(`Import of an embedded library failed: ${e}`)
         })
       });
 

--- a/alpheios_nemo_ui/data/templates/main/container.html
+++ b/alpheios_nemo_ui/data/templates/main/container.html
@@ -16,6 +16,7 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.6/umd/popper.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.2.1/js/bootstrap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/ua-parser-js@0/dist/ua-parser.min.js"></script>
 
     <meta name="alpheios-pedagogical-text" content="true"/>
     {% if 'greekLit' in objectId %}
@@ -56,45 +57,66 @@
     {% include "main::footer.html" %}
   {% endblock %}
   <script type="text/javascript">
-    document.addEventListener("DOMContentLoaded", function(event) {
-      import ('/assets/nemo.secondary/js/alpheios-embedded.min.js').then(embedLib => {
-        console.info(`Embedded library has been imported successfully`)
+    window.onerror = function(message) {
+      var parser = new UAParser();
+      var browserData = parser.getBrowser();
+      var allowedBrowsers = ['Chrome', 'Firefox', 'Mobile Safari', 'Safari'];
 
-        window.AlpheiosEmbed.importDependencies(
-          { mode: 'custom',
-            libs: { components: '/assets/nemo.secondary/js/alpheios-components.min.js' } }).then(Embedded => {
-          const embedded = new Embedded(
-            {
-               clientId:'alpheios-reader',
-               enabledSelector:'.entry-content',
-               popupInitialPos: {
-                 left: '50px',
-                 top: '230px'
-               },
-              toolbarInitialPos: {
-                top: '220px',
-                right: '15px'
-              },
-              layoutType: 'readingTools',
-              {% if collections['current'] and collections['current']['id'] and 'greek' in collections['current']['id'] %}
-              textLangCode: 'grc'
-              {% else %}
-              textLangCode: 'lat'
-              {% endif %}
-            })
-          embedded.activate().then(function () {
-            import ('/assets/nemo.secondary/js/alpheios-embed-support.js')
-              .then(m => m.embedPostActivation(embedded))
-              .catch(e => console.error(`There is an error importing alpheios-embed-support.js:`, e))
+      if (allowedBrowsers.indexOf(browserData.name) === -1) {
+        console.error('Your browser is not supported by Alpheios Extension. Please use Chrome, Firefox or Safari.')
+      } else {
+        console.error(message)
+      }
+    }
+  </script>
+  <script type="text/javascript">
+      const textLangCode = 'lat'
+      {% if collections['current'] and collections['current']['id'] and 'greek' in collections['current']['id'] %}
+        textLangCode = 'grc'
+      {% endif %}
+
+      const embedProps = {
+        alpheiosEmbedJSURL: '/assets/nemo.secondary/js/alpheios-embedded.min.js',
+        alpheiosEmbedSupportJSURL: '/assets/nemo.secondary/js/alpheios-embed-support.js',
+        alpheiosComponentsJSURL: '/assets/nemo.secondary/js/alpheios-components.min.js',
+        clientProps: {
+                        clientId:'alpheios-reader',
+                        enabledSelector:'.entry-content',
+                        popupInitialPos: {
+                          left: '50px',
+                          top: '230px'
+                        },
+                        toolbarInitialPos: {
+                          top: '220px',
+                          right: '15px'
+                        },
+                        layoutType: 'readingTools',
+                        textLangCode: textLangCode
+                      }
+      }
+
+      document.addEventListener("DOMContentLoaded", function(event) {
+        import (embedProps.alpheiosEmbedJSURL).then(embedLib => {
+          console.info(`Embedded library has been imported successfully`)
+
+          window.AlpheiosEmbed.importDependencies({ 
+            mode: 'custom',
+            libs: { components: embedProps.alpheiosComponentsJSURL } 
+          }).then(Embedded => {
+                const embedded = new Embedded(embedProps.clientProps)
+                embedded.activate().then(function () {
+                  import (embedProps.alpheiosEmbedSupportJSURL)
+                    .then(m => m.embedPostActivation(embedded))
+                    .catch(e => console.error(`There is an error importing alpheios-embed-support.js:`, e))
+                })
+          }).catch(e => {
+            console.error(`Import of an embedded library dependencies failed: ${e}`)
           })
-        }).catch(e => {
-          console.error(`Import of an embedded library dependencies failed: ${e}`)
-        })
 
-      }).catch(e => {
-        console.error(`Import of an embedded library failed: ${e}`)
-      })
-    });
+        }).catch(e => {
+          console.error(`Import of an embedded library failed: ${e}`)
+        })
+      });
 
   </script>
   <script>

--- a/alpheios_nemo_ui/data/templates/main/container.html
+++ b/alpheios_nemo_ui/data/templates/main/container.html
@@ -63,8 +63,9 @@
       var allowedBrowsers = ['Chrome', 'Firefox', 'Mobile Safari', 'Safari'];
 
       if (allowedBrowsers.indexOf(browserData.name) === -1) {
-        console.error('Your browser is not supported by Alpheios Extension. Please use Chrome, Firefox or Safari.')
-        window.alert('Your browser is not supported by Alpheios Extension. Please use Chrome, Firefox or Safari.')
+        var messageNew = 'Alpheios may not work with your browser. Please use Chrome, Firefox or Safari to access this site.';
+        console.error(messageNew);
+        window.alert(messageNew);
       } else {
         console.error(message)
       }


### PR DESCRIPTION
For the issue - https://github.com/alpheios-project/alpheios_nemo_ui/issues/224
I suggest to do it this way:
1. add a lightweight library for checking browser - https://github.com/faisalman/ua-parser-js
2. add an error handler for the window to catch browser unsupported error (it is a commonly used practice)
3. check browser support inside error handler

The error would be printed to console and shown via `window.alert`- for example Edge

![image](https://user-images.githubusercontent.com/12377640/62028845-992de780-b224-11e9-83ed-1c17714ee695.png)
