### PR TITLE
switching to cdn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,5 @@ env.js
 
 # texts
 texts
+
+alpheios_nemo_ui/data/assets/package-lock.json

--- a/alpheios_nemo_ui/data/templates/main/container.html
+++ b/alpheios_nemo_ui/data/templates/main/container.html
@@ -67,7 +67,7 @@
       {% endif %}
 
       const embedProps = {
-        alpheiosEmbedJSURL: '/assets/nemo.secondary/js/alpheios-embedded.min.js',
+        alpheiosEmbedJSURL: 'https://cdn.jsdelivr.net/npm/alpheios-embedded@beta/dist/alpheios-embedded.min.js',
         alpheiosEmbedSupportJSURL: '/assets/nemo.secondary/js/alpheios-embed-support.js',
         alpheiosComponentsJSURL: '/assets/nemo.secondary/js/alpheios-components.min.js',
         clientProps: {
@@ -97,8 +97,7 @@
           console.info(`Embedded library has been imported successfully`)
 
           window.AlpheiosEmbed.importDependencies({
-            mode: 'custom',
-            libs: { components: embedProps.alpheiosComponentsJSURL }
+            mode: 'cdn'
           }).then(Embedded => {
                 const embedded = new Embedded(embedProps.clientProps)
                 embedded.activate().then(function () {


### PR DESCRIPTION
for alpheios-embedded and components

will need to switch from beta to latest channel for embedded at release.

(for a future release, we should externalize this...)