### PR TITLE
Issue 302

### DIFF
--- a/alpheios_nemo_ui/__init__.py
+++ b/alpheios_nemo_ui/__init__.py
@@ -70,6 +70,7 @@ class AlpheiosNemoUI(PluginPrototype):
         ("/typeahead/collections.json", "r_typeahead_json", ["GET"]),
         ("/authorize","r_authorize",["GET"]),
         ("/login","r_login",["GET"]),
+        ("/signup_safari","r_signup_safari",["GET"]),
         ("/logout","r_logout",["GET"]),
         ("/return","r_logout_return",["GET"]),
         ("/userinfo","r_userinfo",["GET"]),
@@ -453,6 +454,16 @@ class AlpheiosNemoUI(PluginPrototype):
             return redirect(session['loginReturn'])
         else:
             return redirect(url_for('.r_index'))
+
+    def r_signup_safari(self):
+        """ Initiate Account Creation for the Safari App Extension
+            This is a route to be used by the Safari App Extension. It creates
+            a version of the Auth0 Universal Login page that only includes the SignUp tab
+            and only allows username-password authentication (no social signin)
+        """
+        session.clear()
+        session['loginReturn'] = request.args.get('next','')
+        return self.auth0.authorize_redirect(redirect_uri=self.external_url_base + "/authorize",audience='alpheios.net:apis',prompt='select_account',mode='signUp',connection='Username-Password-Authentication')
 
     def r_login(self):
         # Clear session stored data

--- a/alpheios_nemo_ui/__init__.py
+++ b/alpheios_nemo_ui/__init__.py
@@ -461,6 +461,11 @@ class AlpheiosNemoUI(PluginPrototype):
             a version of the Auth0 Universal Login page that only includes the SignUp tab
             and only allows username-password authentication (no social signin)
         """
+        # clearing the session because signup seems to invalidate any existing Auth0 session token
+        # even if we don't explicitly login after signup (which is how the universal form is setup for this,
+        # with loginAfterSignUp=true if mode === 'signUp'
+        session.clear()
+        session['loginReturn'] = request.args.get('next','')
         return self.auth0.authorize_redirect(redirect_uri=self.external_url_base + "/authorize",audience='alpheios.net:apis',prompt='select_account',mode='signUp',connection='Username-Password-Authentication')
 
     def r_login(self):

--- a/alpheios_nemo_ui/__init__.py
+++ b/alpheios_nemo_ui/__init__.py
@@ -461,8 +461,6 @@ class AlpheiosNemoUI(PluginPrototype):
             a version of the Auth0 Universal Login page that only includes the SignUp tab
             and only allows username-password authentication (no social signin)
         """
-        session.clear()
-        session['loginReturn'] = request.args.get('next','')
         return self.auth0.authorize_redirect(redirect_uri=self.external_url_base + "/authorize",audience='alpheios.net:apis',prompt='select_account',mode='signUp',connection='Username-Password-Authentication')
 
     def r_login(self):


### PR DESCRIPTION
I was hoping to leave any existing alpheios_nemo_ui session and login intact, but it seems that signing up for a new account will invalidate your existing Auth0 session, even if the configuration is setup to not log the user in automatically after signup.

Going along with this change were changes to the Universal Login form on Auth0, to set the following parameters if the mode==='signUp':

```
allowLogin: config.extraParams.mode === 'signUp' ? false : true,
loginAfterSignUp: config.extraParams.mode == 'signUp'? false : true
```

allowLogin prevents the display of the login form
loginAfterSignUp prevents automatic login after signup

If/when we end up doing a non-safari specific sign route we will need to change this, so that we get different behavior for the different applications (i.e. for the webextension and the text environment we would probably want to allow login from signup) but this should be okay for now.